### PR TITLE
moodle requires xml

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,6 +9,7 @@ _moodle_requirements:
     - php-intl
     - php-xmlrpc
     - php-soap
+    - php-xml
   RedHat-8:
     - php-mysqlnd
     - php-zip
@@ -16,18 +17,21 @@ _moodle_requirements:
     - php-intl
     - php-xmlrpc
     - php-soap
+    - php-xml
   Debian:
     - php-mysqli
     - php-zip
     - php-gd
     - php-intl
     - php-soap
+    - php-xml
   Debian-testing:
     - php-mysql
     - php-zip
     - php-gd
     - php-intl
     - php-soap
+    - php-xml
   Suse:
     - php7-mysql
     - php7-zip


### PR DESCRIPTION
Error message: Moodle requires the xml PHP extension. Please install or enable the xml extension.

```
root@moodle:/var/www/html/moodle# curl localhost/moodle/admin/index.php -H Host:moodle.mydomain.com
Moodle requires the xml PHP extension. Please install or enable the xml extension.
```

moodle 401 on ubuntu 22.04 (lxc)